### PR TITLE
feat: Modify exists check queries to not always return error when false

### DIFF
--- a/api/app/services/user_service.go
+++ b/api/app/services/user_service.go
@@ -113,17 +113,25 @@ func (u *userService) CheckEmailExists(ctx context.Context, email string) (*bool
 	user, err := u.client.User.Query().Where(user.EmailEQ(email)).Only(ctx)
 	isEmailExists := user != nil
 	if !isEmailExists {
-		return &isEmailExists, err
+		if ent.IsNotFound(err) {
+			return &isEmailExists, nil // false, i.e. not exists
+		} else {
+			return nil, err // other kind of error
+		}
 	}
 
-	return &isEmailExists, nil
+	return &isEmailExists, nil // true, i.e. exists
 }
 
 func (u *userService) CheckScreenNameExists(ctx context.Context, screenName string) (*bool, error) {
 	user, err := u.client.User.Query().Where(user.ScreenNameEQ(screenName)).Only(ctx)
 	isScreenNameExists := user != nil
 	if !isScreenNameExists {
-		return &isScreenNameExists, err
+		if ent.IsNotFound(err) {
+			return &isScreenNameExists, err
+		} else {
+			return nil, err
+		}
 	}
 
 	return &isScreenNameExists, nil


### PR DESCRIPTION
- Modify screenNameExists and emailExists queries to return false without an error if the error type is not found error, as this is an expected error. Return with an error when get another kind of error.