### PR TITLE
fix: Modify CheckScreenNameExists to return nil error on not found

### DIFF
--- a/api/app/services/user_service.go
+++ b/api/app/services/user_service.go
@@ -128,7 +128,7 @@ func (u *userService) CheckScreenNameExists(ctx context.Context, screenName stri
 	isScreenNameExists := user != nil
 	if !isScreenNameExists {
 		if ent.IsNotFound(err) {
-			return &isScreenNameExists, err
+			return &isScreenNameExists, nil
 		} else {
 			return nil, err
 		}


### PR DESCRIPTION
- Fix omitted change on return value of CheckScreenNameExists when the error type was not found error.