### PR TITLE
fix: Let relay compiler correctly generate params.text

### DIFF
--- a/frontend/app/components/field/EmailField.tsx
+++ b/frontend/app/components/field/EmailField.tsx
@@ -11,8 +11,6 @@ import type { FormFieldProps } from '@types-constants/form';
 
 import type { EmailFieldQuery } from '@relay/__generated__/EmailFieldQuery.graphql';
 
-// Replace params.text in relay/__generated__/screennameFieldQuery.graphql.ts with this if it is null
-// 'query emailFieldQuery(\n  $email: String!\n) {\n  emailExists(email: $email)\n}\n'
 export const emailExistsQuery = graphql`
   query EmailFieldQuery($email: String!) {
     emailExists(email: $email)

--- a/frontend/app/components/field/ScreenNameField.tsx
+++ b/frontend/app/components/field/ScreenNameField.tsx
@@ -11,8 +11,6 @@ import type { FormFieldProps } from '@types-constants/form';
 
 import type { ScreenNameFieldQuery } from '@relay/__generated__/ScreenNameFieldQuery.graphql';
 
-// Replace params.text in relay/__generated__/screennameFieldQuery.graphql.ts with this if it is null
-// 'query screennameFieldQuery(\n  $screenName: String!\n) {\n  screenNameExists(screenName: $screenName)\n}\n'
 export const screenNameExistsQuery = graphql`
   query ScreenNameFieldQuery($screenName: String!) {
     screenNameExists(screenName: $screenName)

--- a/frontend/app/relay/__generated__/EmailFieldQuery.graphql.ts
+++ b/frontend/app/relay/__generated__/EmailFieldQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf3b8524f8372994ebb63db5f9629fae>>
+ * @generated SignedSource<<5a0460fc79ce705fdc193070e6f471da>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ClientRequest, ClientQuery } from 'relay-runtime';
+import { ConcreteRequest, Query } from 'relay-runtime';
 export type EmailFieldQuery$variables = {
   email: string;
 };
@@ -20,7 +20,7 @@ export type EmailFieldQuery = {
   variables: EmailFieldQuery$variables;
 };
 
-const node: ClientRequest = (function () {
+const node: ConcreteRequest = (function () {
   var v0 = [
       {
         defaultValue: null,
@@ -30,22 +30,17 @@ const node: ClientRequest = (function () {
     ],
     v1 = [
       {
-        kind: 'ClientExtension',
-        selections: [
+        alias: null,
+        args: [
           {
-            alias: null,
-            args: [
-              {
-                kind: 'Variable',
-                name: 'email',
-                variableName: 'email',
-              },
-            ],
-            kind: 'ScalarField',
-            name: 'emailExists',
-            storageKey: null,
+            kind: 'Variable',
+            name: 'email',
+            variableName: 'email',
           },
         ],
+        kind: 'ScalarField',
+        name: 'emailExists',
+        storageKey: null,
       },
     ];
   return {
@@ -66,12 +61,12 @@ const node: ClientRequest = (function () {
       selections: v1 /*: any*/,
     },
     params: {
-      cacheID: '8bf572ff2bb584e9a3aa4df417d896b4',
+      cacheID: '6fa1a90a5a637f8497283e5e9f68993a',
       id: null,
       metadata: {},
       name: 'EmailFieldQuery',
       operationKind: 'query',
-      text: 'query emailFieldQuery(\n  $email: String!\n) {\n  emailExists(email: $email)\n}\n',
+      text: 'query EmailFieldQuery(\n  $email: String!\n) {\n  emailExists(email: $email)\n}\n',
     },
   };
 })();

--- a/frontend/app/relay/__generated__/ScreenNameFieldQuery.graphql.ts
+++ b/frontend/app/relay/__generated__/ScreenNameFieldQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cbb05a8510439b99c98b82cf9c533959>>
+ * @generated SignedSource<<4749159d084b83f5ce572fd74b177333>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ClientRequest, ClientQuery } from 'relay-runtime';
+import { ConcreteRequest, Query } from 'relay-runtime';
 export type ScreenNameFieldQuery$variables = {
   screenName: string;
 };
@@ -20,7 +20,7 @@ export type ScreenNameFieldQuery = {
   variables: ScreenNameFieldQuery$variables;
 };
 
-const node: ClientRequest = (function () {
+const node: ConcreteRequest = (function () {
   var v0 = [
       {
         defaultValue: null,
@@ -30,22 +30,17 @@ const node: ClientRequest = (function () {
     ],
     v1 = [
       {
-        kind: 'ClientExtension',
-        selections: [
+        alias: null,
+        args: [
           {
-            alias: null,
-            args: [
-              {
-                kind: 'Variable',
-                name: 'screenName',
-                variableName: 'screenName',
-              },
-            ],
-            kind: 'ScalarField',
-            name: 'screenNameExists',
-            storageKey: null,
+            kind: 'Variable',
+            name: 'screenName',
+            variableName: 'screenName',
           },
         ],
+        kind: 'ScalarField',
+        name: 'screenNameExists',
+        storageKey: null,
       },
     ];
   return {
@@ -66,12 +61,12 @@ const node: ClientRequest = (function () {
       selections: v1 /*: any*/,
     },
     params: {
-      cacheID: '5f470779f36b396e6aeec715bdc579a0',
+      cacheID: '61b390a8b5381018225e6be00ba4034d',
       id: null,
       metadata: {},
       name: 'ScreenNameFieldQuery',
       operationKind: 'query',
-      text: 'query screennameFieldQuery(\n  $screenName: String!\n) {\n  screenNameExists(screenName: $screenName)\n}\n',
+      text: 'query ScreenNameFieldQuery(\n  $screenName: String!\n) {\n  screenNameExists(screenName: $screenName)\n}\n',
     },
   };
 })();

--- a/frontend/schema/schema.graphql
+++ b/frontend/schema/schema.graphql
@@ -158,6 +158,8 @@ type Query {
     """
     where: UserWhereInput
   ): UserConnection!
+  emailExists(email: String!): Boolean
+  screenNameExists(screenName: String!): Boolean
 }
 """
 The builtin Time type
@@ -667,8 +669,4 @@ type SigninResponse {
   userId: ID!
   accessToken: String!
   refreshToken: String!
-}
-extend type Query {
-  emailExists(email: String!): Boolean
-  screenNameExists(screenName: String!): Boolean
 }


### PR DESCRIPTION
- Move queries under `extend type Query` definition into the original Query type definition
  - Now relay compiler can correctly generate params.text for those queries